### PR TITLE
add source map automatically with toString({ map: true })

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,15 @@ module.exports = function astTransform (source, options, cb) {
 
   walk(ast, null, cb || function () {})
 
-  string.inspect = string.toString
+  var toString = string.toString.bind(string)
+  string.toString = function (opts) {
+    var src = toString()
+    if (opts && opts.map) {
+      src += '\n' + convertSourceMap.fromObject(getSourceMap()).toComment() + '\n'
+    }
+    return src
+  }
+  string.inspect = toString
   string.walk = function (cb) {
     walk(ast, null, cb)
   }


### PR DESCRIPTION
might be a bit easier. browserify transforms can just do `.toString(opts._flags.debug)`.